### PR TITLE
use rc to get rid of hardcoded configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+module.exports = require('rc')('gittorrent', {
+  dht: {
+    bootstrap: [
+      'dht.gittorrent.org:6881',
+      'core.gittorrent.org:6881'
+    ],
+    listen: 6881,
+    announce: 30000
+  },
+  key: 'ed25519.key'
+})

--- a/git-remote-gittorrent
+++ b/git-remote-gittorrent
@@ -11,6 +11,7 @@ var Swarm = require('bittorrent-swarm')
 var ut_gittorrent = require('ut_gittorrent')
 var WebTorrent = require('webtorrent')
 var zeroFill = require('zero-fill')
+var config = require('./config')
 
 // BitTorrent client version string (used in peer ID).
 // Generated from package.json major and minor version. For example:
@@ -28,9 +29,8 @@ function die (error) {
 // Gotta enable color manually because stdout isn't a tty.
 var chalk = new Chalk.constructor({enabled: true});
 
-var bootstrap = ['dht.gittorrent.org:6881', 'core.gittorrent.org:6881']
 var dht = new DHT({
-  bootstrap: bootstrap
+  bootstrap: config.dht.bootstrap
 })
 
 // After building a dictionary of references (sha's to branch names), responds
@@ -182,7 +182,7 @@ function get_infohash (sha, branch) {
     wire.ut_gittorrent.on('receivedTorrent', function (infoHash) {
       var client = new WebTorrent({
         dht: {
-          bootstrap: bootstrap
+          bootstrap: config.dht.bootstrap
         },
         tracker: false
       })

--- a/gittorrentd
+++ b/gittorrentd
@@ -14,6 +14,7 @@ var ut_gittorrent = require('ut_gittorrent')
 var ut_metadata = require('ut_metadata')
 var WebTorrent = require('webtorrent')
 var zeroFill = require('zero-fill')
+var config = require('./config')
 
 // BitTorrent client version string (used in peer ID).
 // Generated from package.json major and minor version. For example:
@@ -28,12 +29,10 @@ function die (error) {
   process.exit(1)
 }
 
-var bootstrap = ['dht.gittorrent.org:6881', 'core.gittorrent.org:6881']
-
 var dht = new DHT({
-  bootstrap: bootstrap
+  bootstrap: config.dht.bootstrap
 })
-dht.listen(6881)
+dht.listen(config.dht.listen)
 
 var announcedRefs = {
 }
@@ -44,17 +43,16 @@ var userProfile = {
 var key = create_or_read_keyfile()
 
 function create_or_read_keyfile () {
-  var filename = 'ed25519.key'
-  if (!fs.existsSync(filename)) {
+  if (!fs.existsSync(config.key)) {
     var keypair = new EC('ed25519').genKeyPair()
-    fs.writeFileSync(filename, JSON.stringify({
+    fs.writeFileSync(config.key, JSON.stringify({
       pub: keypair.getPublic('hex'),
       priv: keypair.getPrivate('hex')
     }))
   }
 
   // Okay, now the file exists, whether created here or not.
-  var key = JSON.parse(fs.readFileSync('ed25519.key').toString())
+  var key = JSON.parse(fs.readFileSync(config.key).toString())
   return ed25519.keyPair({
     priv: key.priv,
     privEnc: 'hex',
@@ -110,7 +108,7 @@ dht.on('ready', function () {
             branch = branch[1]
             console.log('Announcing ' + sha + ' for ' + branch + ' on repo ' + repo)
             announcedRefs[sha] = repo
-            dht.announce(sha, 30000, function (err) {
+            dht.announce(sha, config.dht.announce, function (err) {
               if (err !== null) {
                 console.log('Announced ' + sha)
               }
@@ -188,7 +186,7 @@ dht.on('ready', function () {
         } else {
           console.error('Finished writing ' + filename)
           var webtorrent = new WebTorrent({
-            dht: {bootstrap: bootstrap},
+            dht: {bootstrap: config.dht.bootstrap},
             tracker: false
           })
           webtorrent.seed(filename, function onTorrent (torrent) {
@@ -207,5 +205,5 @@ dht.on('ready', function () {
       pack.stdin.write(sha + '\n')
       pack.stdin.write('--not\n\n')
     })
-  }).listen(30000)
+  }).listen(config.dht.announce)
 })

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "inherits": "^2.0.1",
     "magnet-uri": "^4.0.0",
     "prettyjson": "^1.1.2",
+    "rc": "^1.0.3",
     "ut_gittorrent": "^0.1.0",
     "ut_metadata": "^2.7.3",
     "webtorrent": "^0.32.0",


### PR DESCRIPTION
[`rc`](https://github.com/dominictarr/rc) allows you to configure anything, either via flags on cli and/or environment variables and/or configuration files (handles both json and ini format).

This change makes it trivial to change any ports, bootstrap nodes or key file.