### PR TITLE
update webtorrent version for iojs support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rc": "^1.0.3",
     "ut_gittorrent": "^0.1.0",
     "ut_metadata": "^2.7.3",
-    "webtorrent": "^0.32.0",
+    "webtorrent": "^0.48.0",
     "zero-fill": "^2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Solves:

```
make: Leaving directory '/home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc/node_modules/node-gyp/lib/build.js:269:23)
gyp ERR! stack     at emitTwo (events.js:87:13)
gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:199:12)
gyp ERR! System Linux 3.16.0-38-generic
gyp ERR! command "/usr/local/bin/iojs" "/home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc/node_modules/node-gyp/bin/node-gyp.js" "build" "--fallback-to-build" "--module=/home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc/build/wrtc/v0.0.55/Release/node-v44-linux-x64/wrtc.node" "--module_name=wrtc" "--module_path=/home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc/build/wrtc/v0.0.55/Release/node-v44-linux-x64"
gyp ERR! cwd /home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc
gyp ERR! node -v v2.2.1
gyp ERR! node-gyp -v v1.0.3
gyp ERR! not ok 
node-pre-gyp ERR! build error 
node-pre-gyp ERR! stack Error: Failed to execute '/usr/local/bin/iojs /home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc/build/wrtc/v0.0.55/Release/node-v44-linux-x64/wrtc.node --module_name=wrtc --module_path=/home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc/build/wrtc/v0.0.55/Release/node-v44-linux-x64' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc/node_modules/node-pre-gyp/lib/util/compile.js:73:29)
node-pre-gyp ERR! stack     at emitTwo (events.js:87:13)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:763:16)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:210:5)
node-pre-gyp ERR! System Linux 3.16.0-38-generic
node-pre-gyp ERR! command "/usr/local/bin/iojs" "/home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /home/lms/src/GitTorrent/node_modules/webtorrent/node_modules/torrent-discovery/node_modules/bittorrent-tracker/node_modules/wrtc
node-pre-gyp ERR! node -v v2.2.1
node-pre-gyp ERR! node-pre-gyp -v v0.6.4
node-pre-gyp ERR! not ok 
```